### PR TITLE
Allow use environment variable for username

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/sqlplusscriptrunner/SQLPlusRunnerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/sqlplusscriptrunner/SQLPlusRunnerBuilder.java
@@ -83,7 +83,7 @@ public class SQLPlusRunnerBuilder extends Builder {
 		EnvVars env = build.getEnvironment(listener);
 		sqlScript = env.expand(sqlScript);
 
-		SQLPlusRunner sqlPlusRunner = new SQLPlusRunner(listener, getDescriptor().isHideSQLPlusVersion(), user,
+		SQLPlusRunner sqlPlusRunner = new SQLPlusRunner(listener, getDescriptor().isHideSQLPlusVersion(), env.expand(user),
 				password, instance, sqlScript, getDescriptor().oracleHome, scriptType, customOracleHome,
 				getDescriptor().tryToDetectOracleHome,getDescriptor().isDebug());
 


### PR DESCRIPTION
Add ability to populate user from environment variable/job parameters.
Use case: running on different environments where username corresponds to environment name.
![sqlplus_pr](https://user-images.githubusercontent.com/16775850/29603689-0240423c-87dd-11e7-9485-b98a28913557.png)
