### PR TITLE
Add Credentials Plugin support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,14 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>credentials</artifactId>
+			<version>2.1.17</version>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/resources/org/jenkinsci/plugins/sqlplusscriptrunner/SQLPlusRunnerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/sqlplusscriptrunner/SQLPlusRunnerBuilder/config.jelly
@@ -1,10 +1,7 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%user}" field="user">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="${%password}" field="password">
-    <f:password />
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+  <f:entry title="${%Credentials}" field="credentialsId">
+    <c:select/>
   </f:entry>
   <f:entry title="${%instance}" field="instance">
     <f:textbox />


### PR DESCRIPTION
Hi,

As mentioned in #23 , would be nice to support the Credentials Plugin. So that users can re-use existing credentials. This pull request addresses just this point, but in the future we could also add a custom credential type, that allowed to select user+pass+schema (not sure if that makes sense though).

From the implementators documentation:

>If I am using a username and password to connect to a service, we have the choice of using the
StandardUsernamePasswordCredentials interface or creating our own type.

So let's use it!

Here's the example I used as reference: https://github.com/aparsekar/status-polling-plugin/blob/c36772bcb84c675ee22d904d346eb3cd3897edfe/src/main/java/org/jenkinsci/plugins/ajpjenkins/JobStatusBuilder.java

Alas I didn't have time to write a unit test, nor to properly test backward compatibility. I did test the basic workflow, where I started `mvn clean package hpi:run`, then created my credentials in the global scope, and then finally created a new job.

The credentials dropdown is correctly displayed, but I didn't play with values to see if the validation is working correctly.

So as one can clearly see, I could have done much better testing here. But maybe @boaglio or somebody else could have a look and do some more thorough tests? Here's what I think needs to be tested/confirmed:

- The old behaviour of finding an environment variable with user/pass is gone with the credentials plugin (behaviour backward incompatible)
- I tried to add a new constructor, but keep the old one still working. As with an old user+pass, we can't really locate a credentials, I simply check if there is no credentials, but user+pass, then we use the latter. If we have credentials, then don't bother and just use it... but if we don't have either of these, then the job fails.
    * So would be nice to test the following scenario: I have an old job, created with the old plugin, with user+pass. Then I upgrade to use this version (just mvn package, save the hpi somewhere else, and install manually for testing). And test that the job is working with user+pass. If you update the configuration, it won't allow you to keep user+pass, and you will be forced to choose a credentials. Save the job with a credential, and it should work as expected.
- Didn't try the scenarios of saving a job without credentials
- I don't have SQLPlus or Oracle, but debugging I confirmed the values were persisted by Jenkins/stapler, and that I could see them until before the job fails saying that I have to set up ORACLE_HOME

Hope that helps
Bruno